### PR TITLE
Gracefully handle empty name file

### DIFF
--- a/pkg/namer.go
+++ b/pkg/namer.go
@@ -5,6 +5,7 @@ package dnsbench
 
 import (
 	"bufio"
+	"errors"
 	"io"
 	"sync/atomic"
 
@@ -24,6 +25,11 @@ func FileNamer(file io.Reader) (Namer, error) {
 	for scanner.Scan() {
 		names = append(names, Name{Name: dns.Fqdn(scanner.Text()), Type: dns.TypeA})
 	}
+
+	if len(names) == 0 {
+		return nil, errors.New("no names found in file")
+	}
+
 	i := int64(-1)
 	n := func() Name {
 		return names[atomic.AddInt64(&i, 1)%int64(len(names))]

--- a/pkg/namer_test.go
+++ b/pkg/namer_test.go
@@ -24,3 +24,18 @@ func TestNamer(t *testing.T) {
 		}
 	}
 }
+
+func TestNamerEmptyFile(t *testing.T) {
+	names := []string{}
+	reader := strings.NewReader(strings.Join(names, "\n"))
+
+	namer, err := FileNamer(reader)
+
+	if err == nil {
+		t.Error("expected error with message \"no names found in file\", but got nil")
+	}
+
+	if namer != nil {
+		t.Error("expected namer to be nil")
+	}
+}


### PR DESCRIPTION
Added a check to return helpful error to user if name file appears to be empty.

```
(base) projects/dnsbench % echo -n "" | ./dist/dnsbench run
Error: no names found in file
Usage:
  dnsbench run [command] [flags]

...
```

Closes https://github.com/askmediagroup/dnsbench/issues/11