### PR TITLE
Remove unneeded go get from CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,6 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.21'
-      - name: Install dependencies
-        run: go get .
       - name: Build
         run: make build
       - name: Test


### PR DESCRIPTION
CI workflow has an error due to the dep fetch step using `go get .` which doesn't work for our repo. The call to `go get` isn't really needed to removing it instead of updating it to work with our package structure.