### PR TITLE
Cleanups for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,12 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.21'
+      - name: Login to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Release
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,6 +7,7 @@ before:
 builds:
 - main: ./cmd/dnsbench
   binary: dnsbench
+  mod_timestamp: "{{ .CommitTimestamp }}"
   
   env:
   - CGO_ENABLED=0
@@ -19,7 +20,7 @@ builds:
    - "-s -w"
    - "-X github.com/askmediagroup/dnsbench/pkg/cmd.dnsbenchVersion={{ .Version }}"
    - "-X github.com/askmediagroup/dnsbench/pkg/cmd.gitCommit={{ .Commit }}"
-   - "-X github.com/askmediagroup/dnsbench/pkg/cmd.buildDate={{ .Date }}"
+   - "-X github.com/askmediagroup/dnsbench/pkg/cmd.buildDate={{ .CommitDate }}"
 
   goos:
   - darwin
@@ -49,7 +50,7 @@ dockers:
       - "--label=org.opencontainers.image.licenses=Apache-2.0"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.created={{ time \"2006-01-02T15:04:05Z07:00\" }}"
+      - "--label=org.opencontainers.image.created={{ .CommitDate }}"
     image_templates:
       - "ghcr.io/askmediagroup/dnsbench:{{ .Version }}-amd64"
   
@@ -67,7 +68,7 @@ dockers:
       - "--label=org.opencontainers.image.licenses=Apache-2.0"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.created={{ time \"2006-01-02T15:04:05Z07:00\" }}"
+      - "--label=org.opencontainers.image.created={{ .CommitDate }}"
     image_templates:
       - "ghcr.io/askmediagroup/dnsbench:{{ .Version }}-arm64"
 
@@ -93,7 +94,7 @@ docker_manifests:
       - ghcr.io/askmediagroup/dnsbench:{{ .Version }}-arm64
 
 checksum:
-  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
+  name_template: "checksums.txt"
 
 archives:
   - format: binary

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,15 @@ export PATH := $(abspath bin/):${PATH}
 clean:
 	rm -rf dist/
 
+LD_FLAGS=-ldflags " \
+    -X github.com/askmediagroup/dnsbench/pkg/cmd.dnsbenchVersion=$(shell git describe --tags --dirty --broken) \
+    -X github.com/askmediagroup/dnsbench/pkg/cmd.gitCommit=$(shell git rev-parse HEAD) \
+    -X github.com/askmediagroup/dnsbench/pkg/cmd.buildDate=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
+	"
 .PHONY: build
 build: dist/dnsbench
 dist/dnsbench:
-	go build -o dist/dnsbench cmd/dnsbench/main.go
+	go build $(LD_FLAGS) -o dist/dnsbench cmd/dnsbench/main.go
 
 .PHONY: test
 test:

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -22,8 +22,8 @@ type version struct {
 	dnsenchVersion string
 	gitCommit      string
 	buildDate      string
-	goOs           string
-	goArch         string
+	goos           string
+	goarch         string
 }
 
 func newVersionCommand() *cobra.Command {
@@ -31,7 +31,7 @@ func newVersionCommand() *cobra.Command {
 		Use:   "version",
 		Short: "Display program version.",
 		Run: func(_ *cobra.Command, _ []string) {
-			fmt.Printf("Version: %+v\n", version{
+			fmt.Printf("Version: %#v\n", version{
 				dnsbenchVersion,
 				gitCommit,
 				buildDate,


### PR DESCRIPTION
Makes several changes to fix and clean things up for the release workflow.

* Adds missing release workflow step to login to the container registry.
* Include field names in version output
* Include ldflags in make build target
* Make goreleaser builds reproducible